### PR TITLE
Fix Property [$rows] not found on component pulse-slow-jobs

### DIFF
--- a/config/filament-laravel-pulse.php
+++ b/config/filament-laravel-pulse.php
@@ -121,6 +121,7 @@ return [
                 'md' => 5,
                 'xl' => 5,
             ],
+            'rows' => 2,
             'cols' => 'full',
             'ignoreAfter' => '1 day',
             'isDiscovered' => true,

--- a/src/Widgets/PulseSlowJobs.php
+++ b/src/Widgets/PulseSlowJobs.php
@@ -14,6 +14,8 @@ class PulseSlowJobs extends Widget
 
     protected string $ignoreAfter;
 
+    protected int $rows;
+
     public function __construct()
     {
         $config = config('filament-laravel-pulse.components.slow-jobs');
@@ -21,6 +23,7 @@ class PulseSlowJobs extends Widget
             'md' => 5,
             'xl' => 5,
         ];
+        $this->rows = $config['rows'] ?? 2;
         $this->cols = $config['cols'] ?? 'full';
         $this->ignoreAfter = $config['ignoreAfter'] ?? '1 hour';
         self::$isDiscovered = $config['isDiscovered'] ?? true;


### PR DESCRIPTION
Adding `PulseSlowJobs::class,` to `public function getWidgets(): array` causes an exception: `Property [$rows] not found on component: [dotswan.filament-laravel-pulse.widgets.pulse-slow-jobs]`. This PR fixes that by setting a default. I copied the code from the `PulseUsage` widget
