### PR TITLE
Fix naming for PulseSlowOutGoingRequests

### DIFF
--- a/config/filament-laravel-pulse.php
+++ b/config/filament-laravel-pulse.php
@@ -62,7 +62,7 @@ return [
             'columnStart' => [],
         ],
 
-        'slow-out-going' => [
+        'slow-out-going-requests' => [
             'columnSpan' => 'full',
             'cols' => 'full',
             'ignoreAfter' => '1 day',

--- a/src/Widgets/PulseSlowOutGoingRequests.php
+++ b/src/Widgets/PulseSlowOutGoingRequests.php
@@ -16,7 +16,7 @@ class PulseSlowOutGoingRequests extends Widget
 
     public function __construct()
     {
-        $config = config('filament-laravel-pulse.components.slow-out-going-requests');
+        $config = config('filament-laravel-pulse.components.slow-out-going-requests') ?? config('filament-laravel-pulse.components.slow-out-going');
         $this->columnSpan = $config['columnSpan'] ?? [
             'md' => 5,
             'xl' => 5,


### PR DESCRIPTION
Currently the `PulseSlowOutGoingRequests` doesn't respond to the config due to a naming mismatch. This PR fixes that mismatch in a backwards compatible way.