### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^8.2",
         "filament/filament": "^4.0 || ^5.0",
         "spatie/laravel-package-tools": "^1.15.0",
-        "mohaphez/pulse": "^1.7"
+        "laravel/pulse": "^1.0"
     },
     "require-dev": {
         "laravel/framework": "^11.28|^12.0|^13.0",

--- a/src/FilamentLaravelPulseServiceProvider.php
+++ b/src/FilamentLaravelPulseServiceProvider.php
@@ -74,7 +74,7 @@ class FilamentLaravelPulseServiceProvider extends PackageServiceProvider
     protected function getAssets(): array
     {
         return [
-            Css::make('filament-laravel-pulse', __DIR__.'/../../../laravel/pulse/dist/pulse.css'),
+            //Css::make('filament-laravel-pulse', __DIR__.'/../../../laravel/pulse/dist/pulse.css'),
             Js::make('filament-laravel-pulse', __DIR__.'/../resources/dist/js/filament-laravel-pulse.js'),
         ];
     }

--- a/src/FilamentLaravelPulseServiceProvider.php
+++ b/src/FilamentLaravelPulseServiceProvider.php
@@ -74,7 +74,7 @@ class FilamentLaravelPulseServiceProvider extends PackageServiceProvider
     protected function getAssets(): array
     {
         return [
-            Css::make('filament-laravel-pulse', __DIR__.'/../../../mohaphez/pulse/dist/pulse.css'),
+            Css::make('filament-laravel-pulse', __DIR__.'/../../../laravel/pulse/dist/pulse.css'),
             Js::make('filament-laravel-pulse', __DIR__.'/../resources/dist/js/filament-laravel-pulse.js'),
         ];
     }


### PR DESCRIPTION
Hello! 👋

Currently, this package requires **mohaphez/pulse**, which has strict requirements for **illuminate/support** up to ^12.0. Because of this transitive dependency, users cannot install **dotswan/filament-laravel-pulse** alongside the newly released Laravel 13.

This PR replaces the mohaphez/pulse fork with the official laravel/pulse package, which already supports Laravel 13 natively.